### PR TITLE
Run rubocop just once (respecting excludes specified in .rubocop.yml)

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -37,11 +37,10 @@ module Danger
     private
 
     def rubocop(files_to_lint)
-      rubocop_results = files_to_lint.flat_map do |f|
-        prefix = File.exist?('Gemfile') ? 'bundle exec' : ''
-        JSON.parse(`#{prefix} rubocop -f json #{f}`)['files']
-      end
-      rubocop_results.select { |f| f['offenses'].count > 0 }
+      rubocop_output = `#{'bundle exec' if File.exist?('Gemfile')} rubocop -f json`
+
+      JSON.parse(rubocop_output)['files']
+        .select { |f| files_to_lint.include?(f['path']) && f['offenses'].any? }
     end
 
     def offenses_message(offending_files)

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -26,7 +26,6 @@ module Danger
     #
     def lint(files = nil)
       files_to_lint = files ? Dir.glob(files) : (git.modified_files + git.added_files)
-      files_to_lint.select! { |f| f.end_with? 'rb' }
 
       offending_files = rubocop(files_to_lint)
       return if offending_files.empty?

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -36,7 +36,7 @@ module Danger
     private
 
     def rubocop(files_to_lint)
-      rubocop_output = `#{'bundle exec' if File.exist?('Gemfile')} rubocop -f json`
+      rubocop_output = `#{'bundle exec ' if File.exist?('Gemfile')}rubocop -f json`
 
       JSON.parse(rubocop_output)['files']
         .select { |f| files_to_lint.include?(f['path']) && f['offenses'].any? }

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -25,19 +25,28 @@ module Danger
                     'location' => { 'line' => 13 }
                   }
                 ]
+              },
+              {
+                'path' => 'spec/fixtures/another_ruby_file.rb',
+                'offenses' => [
+                  {
+                    'message' => "Don't do that!",
+                    'location' => { 'line' => 23 }
+                  }
+                ]
               }
             ]
           }
           @rubocop_response = response.to_json
         end
 
-        it 'handles a known rubocop report' do
+        it 'handles a rubocop report for specified files' do
           allow(@rubocop).to receive(:`)
             .with('bundle exec rubocop -f json')
             .and_return(@rubocop_response)
 
           # Do it
-          @rubocop.lint('spec/fixtures/*.rb')
+          @rubocop.lint('spec/fixtures/ruby*.rb')
 
           output = @rubocop.status_report[:markdowns].first
 
@@ -46,7 +55,25 @@ module Danger
           # A title
           expect(output).to include('Rubocop violations')
           # A warning
-          expect(output).to include("ruby_file.rb | 13   | Don't do that!")
+          expect(output).to include("spec/fixtures/ruby_file.rb | 13   | Don't do that!")
+        end
+
+        it 'handles a rubocop report for files changed in the PR' do
+          allow(@rubocop.git).to receive(:added_files).and_return([])
+          allow(@rubocop.git).to receive(:modified_files)
+            .and_return(["spec/fixtures/another_ruby_file.rb"])
+
+          allow(@rubocop).to receive(:`)
+            .with('bundle exec rubocop -f json')
+            .and_return(@rubocop_response)
+
+          @rubocop.lint
+
+          output = @rubocop.status_report[:markdowns].first
+
+          expect(output).to_not be_empty
+          expect(output).to include('Rubocop violations')
+          expect(output).to include("spec/fixtures/another_ruby_file.rb | 23   | Don't do that!")
         end
 
         it 'is formatted as a markdown table' do
@@ -66,19 +93,6 @@ module Danger
 | spec/fixtures/ruby_file.rb | 13   | Don't do that! |
 EOS
           expect(@rubocop.status_report[:markdowns].first).to eq(formatted_table.chomp)
-        end
-
-        it 'handles no files' do
-          allow(@rubocop.git).to receive(:modified_files)
-            .and_return(['spec/fixtures/ruby_file.rb'])
-          allow(@rubocop.git).to receive(:added_files).and_return([])
-          allow(@rubocop).to receive(:`)
-            .with('bundle exec rubocop -f json')
-            .and_return(@rubocop_response)
-
-          @rubocop.lint
-
-          expect(@rubocop.status_report[:markdowns].first).to_not be_empty
         end
       end
     end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -18,7 +18,7 @@ module Danger
           response = {
             'files' => [
               {
-                'path' => 'ruby_file.rb',
+                'path' => 'spec/fixtures/ruby_file.rb',
                 'offenses' => [
                   {
                     'message' => "Don't do that!",
@@ -33,7 +33,7 @@ module Danger
 
         it 'handles a known rubocop report' do
           allow(@rubocop).to receive(:`)
-            .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
+            .with('bundle exec rubocop -f json')
             .and_return(@rubocop_response)
 
           # Do it
@@ -54,16 +54,16 @@ module Danger
             .and_return(['spec/fixtures/ruby_file.rb'])
           allow(@rubocop.git).to receive(:added_files).and_return([])
           allow(@rubocop).to receive(:`)
-            .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
+            .with('bundle exec rubocop -f json')
             .and_return(@rubocop_response)
 
           @rubocop.lint
 
           formatted_table = <<-EOS
 ### Rubocop violations\n
-| File         | Line | Reason         |
-|--------------|------|----------------|
-| ruby_file.rb | 13   | Don't do that! |
+| File                       | Line | Reason         |
+|----------------------------|------|----------------|
+| spec/fixtures/ruby_file.rb | 13   | Don't do that! |
 EOS
           expect(@rubocop.status_report[:markdowns].first).to eq(formatted_table.chomp)
         end
@@ -73,7 +73,7 @@ EOS
             .and_return(['spec/fixtures/ruby_file.rb'])
           allow(@rubocop.git).to receive(:added_files).and_return([])
           allow(@rubocop).to receive(:`)
-            .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
+            .with('bundle exec rubocop -f json')
             .and_return(@rubocop_response)
 
           @rubocop.lint


### PR DESCRIPTION
Runs only a single Rubocop command, and filters out the appropriate files from the report before generating the table of violations to include in Danger's PR comment.

This means that `Exclude` settings for `AllCops` in `.rubocop.yml` will be respected.

Resolves #6 

Let me know how this looks to you, @ashfurrow :) I've tested it in a private repo of ours and it's working nicely.