### PR TITLE
Update specs for Danger markdown

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,40 +1,41 @@
 PATH
   remote: .
   specs:
-    danger-rubocop (0.2.0)
+    danger-rubocop (0.3.0)
       danger
       rubocop
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     ast (2.3.0)
     bacon (1.2.0)
-    claide (1.0.0)
-    claide-plugins (0.9.1)
+    claide (1.0.1)
+    claide-plugins (0.9.2)
       cork
       nap
       open4 (~> 1.3)
     coderay (1.1.1)
     colored (1.2)
-    cork (0.1.0)
+    cork (0.2.0)
       colored (~> 1.2)
-    danger (2.1.0)
+    danger (4.0.2)
       claide (~> 1.0)
-      claide-plugins (> 0.9.0)
+      claide-plugins (>= 0.9.2)
       colored (~> 1.2)
       cork (~> 0.1)
-      faraday (~> 0)
+      faraday (~> 0.9)
       faraday-http-cache (~> 1.0)
       git (~> 1)
+      kramdown (~> 1.5)
       octokit (~> 4.2)
-      redcarpet (~> 3.3)
       terminal-table (~> 1)
     diff-lcs (1.2.5)
-    faraday (0.9.2)
+    faraday (0.10.0)
       multipart-post (>= 1.2, < 3)
-    faraday-http-cache (1.3.0)
+    faraday-http-cache (1.3.1)
       faraday (~> 0.8)
     ffi (1.9.10)
     formatador (0.2.5)
@@ -53,6 +54,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    kramdown (1.13.1)
     listen (3.0.7)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -69,10 +71,10 @@ GEM
     notiffany (0.1.0)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    octokit (4.3.0)
-      sawyer (~> 0.7.0, >= 0.5.3)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    parser (2.3.1.2)
+    parser (2.3.3.1)
       ast (~> 2.2)
     powerpack (0.1.1)
     prettybacon (0.0.2)
@@ -81,12 +83,12 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    public_suffix (2.0.4)
     rainbow (2.1.0)
     rake (10.5.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
-    redcarpet (3.3.4)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -100,21 +102,22 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
-    rubocop (0.42.0)
+    rubocop (0.46.0)
       parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.8.1)
-    sawyer (0.7.0)
-      addressable (>= 2.3.5, < 2.5)
-      faraday (~> 0.8, < 0.10)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
     shellany (0.0.1)
     slop (3.6.0)
-    terminal-table (1.6.0)
+    terminal-table (1.7.3)
+      unicode-display_width (~> 1.1.1)
     thor (0.19.1)
-    unicode-display_width (1.1.0)
+    unicode-display_width (1.1.1)
     yard (0.9.5)
 
 PLATFORMS
@@ -139,4 +142,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -48,9 +48,7 @@ module Danger
           # Do it
           @rubocop.lint('spec/fixtures/ruby*.rb')
 
-          output = @rubocop.status_report[:markdowns].first
-
-          expect(output).to_not be_empty
+          output = @rubocop.status_report[:markdowns].first.message
 
           # A title
           expect(output).to include('Rubocop violations')
@@ -69,9 +67,8 @@ module Danger
 
           @rubocop.lint
 
-          output = @rubocop.status_report[:markdowns].first
+          output = @rubocop.status_report[:markdowns].first.message
 
-          expect(output).to_not be_empty
           expect(output).to include('Rubocop violations')
           expect(output).to include("spec/fixtures/another_ruby_file.rb | 23   | Don't do that!")
         end
@@ -92,7 +89,7 @@ module Danger
 |----------------------------|------|----------------|
 | spec/fixtures/ruby_file.rb | 13   | Don't do that! |
 EOS
-          expect(@rubocop.status_report[:markdowns].first).to eq(formatted_table.chomp)
+          expect(@rubocop.status_report[:markdowns].first.message).to eq(formatted_table.chomp)
         end
       end
     end


### PR DESCRIPTION
More recent versions of Danger model markdown as a model object instead
of as a String. This caused test breakage against new versions of
Danger.

This change addresses the issue by:

* Updating tests to access the 'message' attribute of Markdown objects