### PR TITLE
Shellescape rubocop file list

### DIFF
--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -96,6 +96,21 @@ module Danger
 EOS
           expect(@rubocop.status_report[:markdowns].first.message).to eq(formatted_table.chomp)
         end
+
+        describe 'a filename with special characters' do
+          it 'is shell escaped' do
+            modified_files = [
+              'spec/fixtures/shellescape/ruby_file_with_parens_(abc).rb',
+              'spec/fixtures/shellescape/ruby_file with spaces.rb',
+              'spec/fixtures/shellescape/ruby_file\'with_quotes.rb'
+            ]
+            allow(@rubocop.git).to receive(:modified_files)
+              .and_return(modified_files)
+            allow(@rubocop.git).to receive(:added_files).and_return([])
+
+            expect { @rubocop.lint }.not_to raise_error
+          end
+        end
       end
     end
   end

--- a/spec/fixtures/shellescape/ruby_file with spaces.rb
+++ b/spec/fixtures/shellescape/ruby_file with spaces.rb
@@ -1,0 +1,1 @@
+# This file intentional left blank-ish.

--- a/spec/fixtures/shellescape/ruby_file'with_quotes.rb
+++ b/spec/fixtures/shellescape/ruby_file'with_quotes.rb
@@ -1,0 +1,1 @@
+# This file intentional left blank-ish.

--- a/spec/fixtures/shellescape/ruby_file_with_parens_(abc).rb
+++ b/spec/fixtures/shellescape/ruby_file_with_parens_(abc).rb
@@ -1,0 +1,1 @@
+# This file intentional left blank-ish.


### PR DESCRIPTION
Files with spaces, quotes, parens and others that need shellescaping
were breaking the rubocop command, because they were not escaped.

[`Shellwords`][1] comes with the ruby stdlib and does exactly what is needed.
It will escape every element of the `files_to_lint` array and then join
it together.

Fixes #12 

✨ 

[1]: https://ruby-doc.org/stdlib-2.3.0/libdoc/shellwords/rdoc/Shellwords.html