### PR TITLE
Support `--force-exclusion` flag to make Rubocop respect exclusions specified in its config file

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -28,15 +28,11 @@ module Danger
     #
     def lint(files = nil)
       files_to_lint = fetch_files_to_lint(files)
+      files_to_report = rubocop(files_to_lint)
 
-      return if offending_files.empty?
+      return if files_to_report.empty?
 
-      markdown offenses_message(offending_files)
-    end
-
-    def offending_files(files = nil)
-      files_to_lint = fetch_files_to_lint(files)
-      rubocop(files_to_lint)
+      markdown offenses_message(files_to_report)
     end
 
     private
@@ -65,10 +61,8 @@ module Danger
     end
 
     def fetch_files_to_lint(files = nil)
-      @files_to_lint ||= begin
-        to_lint = (files ? Dir.glob(files) : (git.modified_files + git.added_files))
-        Shellwords.join(to_lint)
-      end
+      to_lint = (files ? Dir.glob(files) : (git.modified_files + git.added_files))
+      Shellwords.join(to_lint)
     end
   end
 end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -51,7 +51,39 @@ module Danger
             .and_return(response_ruby_file)
 
           # Do it
+          @rubocop.lint(files: 'spec/fixtures/ruby*.rb')
+
+          output = @rubocop.status_report[:markdowns].first.message
+
+          # A title
+          expect(output).to include('Rubocop violations')
+          # A warning
+          expect(output).to include("spec/fixtures/ruby_file.rb | 13   | Don't do that!")
+        end
+
+        it 'handles a rubocop report for specified files (legacy)' do
+          allow(@rubocop).to receive(:`)
+            .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
+            .and_return(response_ruby_file)
+
+          # Do it
           @rubocop.lint('spec/fixtures/ruby*.rb')
+
+          output = @rubocop.status_report[:markdowns].first.message
+
+          # A title
+          expect(output).to include('Rubocop violations')
+          # A warning
+          expect(output).to include("spec/fixtures/ruby_file.rb | 13   | Don't do that!")
+        end
+
+        it 'appends --force-exclusion argument when force_exclusion is set' do
+          allow(@rubocop).to receive(:`)
+            .with('bundle exec rubocop -f json --force-exclusion spec/fixtures/ruby_file.rb')
+            .and_return(response_ruby_file)
+
+          # Do it
+          @rubocop.lint(files: 'spec/fixtures/ruby*.rb', force_exclusion: true)
 
           output = @rubocop.status_report[:markdowns].first.message
 


### PR DESCRIPTION
Hello, first of all, thanks for this plugin!

I'd like Rubocop to lint all ruby files changed in PR except those excluded by `.rubocop.yml`.
I could limit set of files to lint in Dangerfile, but that effectively means duplicating the contents of `.rubocop.yml`, which I'd like to avoid.

Highlights:

* Supports configuration hash as `lint` argument
* Simplifies plugin logic to avoid multiple filesystem hits and implicit parameter passing
* Introduces `force_exclusion` flag to pass `--force-exclusion` to Rubocop.