### PR TITLE
Explains the forced_exclusion option a little more

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ The following keys are supported:
 
 * `files`: array of file names or glob patterns to determine files to lint
 * `force_exclusion`: pass `true` to pass `--force-exclusion` argument to Rubocop.
+  
+  (this option will instruct rubocop to ignore the files that your rubocop config ignores,
+  despite the plugin providing the list of files explicitely)
 
 Passing `files` as only argument is also supported for backward compatibility.
 


### PR DESCRIPTION
Hi,

I've made a whole issue of the problem (https://github.com/ashfurrow/danger-rubocop/issues/19), and found myself a little silly for not noticing it was already solved... so I thought I'd help the next silly person get what the forced_exclusion option is for at first sight ^^

Cheers, and thanks for this super plugin ^^d