### PR TITLE
Add inline_comment option to rubocop.lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The following keys are supported:
 
 * `files`: array of file names or glob patterns to determine files to lint
 * `force_exclusion`: pass `true` to pass `--force-exclusion` argument to Rubocop.
+* `inline_comment`: pass `true` to comment inline of the diffs.
   
   (this option will instruct rubocop to ignore the files that your rubocop config ignores,
   despite the plugin providing the list of files explicitely)

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -129,6 +129,20 @@ EOS
           expect(@rubocop.status_report[:markdowns].first.message).to eq(formatted_table.chomp)
         end
 
+        it 'is reported as line by line' do
+          allow(@rubocop.git).to receive(:modified_files)
+            .and_return(['spec/fixtures/ruby_file.rb'])
+          allow(@rubocop.git).to receive(:added_files).and_return([])
+          allow(@rubocop).to receive(:`)
+            .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
+            .and_return(response_ruby_file)
+
+          @rubocop.lint(inline_comment: true)
+
+          expect(@rubocop.violation_report[:warnings].first.to_s)
+            .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13 }")
+        end
+
         describe 'a filename with special characters' do
           it 'is shell escaped' do
             modified_files = [


### PR DESCRIPTION
This P-R adds support for danger's inline commenting, [introduced about a year ago](https://github.com/danger/danger/pull/412), by passing `file` and `line` arguments to `warn`.

The added test still fails. It'll pass once https://github.com/danger/danger/pull/894 is merged.