### PR TITLE
Add direct danger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The following keys are supported:
 * `files`: array of file names or glob patterns to determine files to lint
 * `force_exclusion`: pass `true` to pass `--force-exclusion` argument to Rubocop.
 * `inline_comment`: pass `true` to comment inline of the diffs.
+* `report_danger`: pass true to report errors to Danger, and break CI.
   
   (this option will instruct rubocop to ignore the files that your rubocop config ignores,
   despite the plugin providing the list of files explicitely)

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -72,7 +72,7 @@ module Danger
     def report_failures(offending_files)
       offending_files.each do |file|
         file['offenses'].each do |offense|
-          fail "#{file['path']} | #{offense['location']['line'] | offense['message']}"
+          fail "#{file['path']} | #{offense['location']['line']} | #{offense['message']}"
         end
       end
     end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -49,6 +49,8 @@ module Danger
 
       rubocop_output = `#{'bundle exec ' if File.exist?('Gemfile')}#{base_command} #{files_to_lint}`
 
+      return [] unless rubocop_output.present?
+
       JSON.parse(rubocop_output)['files']
         .select { |f| f['offenses'].any? }
     end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -49,7 +49,7 @@ module Danger
 
       rubocop_output = `#{'bundle exec ' if File.exist?('Gemfile')}#{base_command} #{files_to_lint}`
 
-      return [] unless rubocop_output.present?
+      return [] if rubocop_output.empty?
 
       JSON.parse(rubocop_output)['files']
         .select { |f| f['offenses'].any? }

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -127,6 +127,7 @@ module Danger
 | spec/fixtures/ruby_file.rb | 13   | Don't do that! |
 EOS
           expect(@rubocop.status_report[:markdowns].first.message).to eq(formatted_table.chomp)
+          expect(@rubocop).not_to receive(:fail)
         end
 
         it 'is reported as line by line' do
@@ -155,6 +156,21 @@ EOS
             allow(@rubocop.git).to receive(:added_files).and_return([])
 
             expect { @rubocop.lint }.not_to raise_error
+          end
+        end
+
+        describe 'report to danger' do
+          let(:fail_msg) { %{spec/fixtures/ruby_file.rb | 13 | Don't do that!} }
+          it 'reports to danger' do
+            allow(@rubocop.git).to receive(:modified_files)
+              .and_return(['spec/fixtures/ruby_file.rb'])
+            allow(@rubocop.git).to receive(:added_files).and_return([])
+            allow(@rubocop).to receive(:`)
+              .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
+              .and_return(response_ruby_file)
+
+            expect(@rubocop).to receive(:fail).with(fail_msg)
+            @rubocop.lint(report_danger: true)
           end
         end
       end


### PR DESCRIPTION
This is kind of rudimentary solution to #18 

Adding  a config `report_danger` boolean flag, to send as Danger messages the Rubocop errors.

TODO: Write some tests