### PR TITLE
Add :fail_on_inline_comment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following keys are supported:
   (this option will instruct rubocop to ignore the files that your rubocop config ignores,
   despite the plugin providing the list of files explicitely)
 * `inline_comment`: pass `true` to comment inline of the diffs.
+* `fail_on_inline_comment`: pass `true` to use `fail` instead of `warn` on inline comment.
 * `report_danger`: pass true to report errors to Danger, and break CI.
 
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -130,18 +130,38 @@ EOS
           expect(@rubocop).not_to receive(:fail)
         end
 
-        it 'is reported as line by line' do
-          allow(@rubocop.git).to receive(:modified_files)
-            .and_return(['spec/fixtures/ruby_file.rb'])
-          allow(@rubocop.git).to receive(:added_files).and_return([])
-          allow(@rubocop).to receive(:`)
-            .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
-            .and_return(response_ruby_file)
+        context 'with inline_comment option' do
+          context 'without fail_on_inline_comment option' do
+            it 'reports violations as line by line warnings' do
+              allow(@rubocop.git).to receive(:modified_files)
+                .and_return(['spec/fixtures/ruby_file.rb'])
+              allow(@rubocop.git).to receive(:added_files).and_return([])
+              allow(@rubocop).to receive(:`)
+                .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
+                .and_return(response_ruby_file)
 
-          @rubocop.lint(inline_comment: true)
+              @rubocop.lint(inline_comment: true)
 
-          expect(@rubocop.violation_report[:warnings].first.to_s)
-            .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13 }")
+              expect(@rubocop.violation_report[:warnings].first.to_s)
+                .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13 }")
+            end
+          end
+
+          context 'with fail_on_inline_comment option' do
+            it 'reports violations as line by line failures' do
+              allow(@rubocop.git).to receive(:modified_files)
+                .and_return(['spec/fixtures/ruby_file.rb'])
+              allow(@rubocop.git).to receive(:added_files).and_return([])
+              allow(@rubocop).to receive(:`)
+                .with('bundle exec rubocop -f json spec/fixtures/ruby_file.rb')
+                .and_return(response_ruby_file)
+
+              @rubocop.lint(fail_on_inline_comment: true, inline_comment: true)
+
+              expect(@rubocop.violation_report[:errors].first.to_s)
+                .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13 }")
+            end
+          end
         end
 
         describe 'a filename with special characters' do


### PR DESCRIPTION
## Problem

I have been running `rubocop` in our application on CircleCI to lint our Ruby code,  so if any offense is detected in a pull request, CircleCI will report a failure and mark CI status as failed.

I want to replace `rubocop` with `danger` with danger-rubocop to use its great inline comment feature but there is a problem that it won't block CI if any offense is detected.

## Solution

Following the problem, I added `:fail_on_inline_comment` option so that we can let `danger` report failures on inline comments instead of warnings. 

### Example

This is an example result with `{ fail_on_inline_comment: true, inline_comment: true }`:

![image](https://user-images.githubusercontent.com/111689/48819788-1bf8cb80-ed95-11e8-9cd0-0861cf55ea6e.png)
