### PR TITLE
add `only_report_new_offenses` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The following keys are supported:
 * `fail_on_inline_comment`: pass `true` to use `fail` instead of `warn` on inline comment.
 * `report_danger`: pass true to report errors to Danger, and break CI.
 * `config`: path to the `.rubocop.yml` file.
+* `only_report_new_offenses`: pass `true` to only report offenses that are in current user's scope.
+   Note that this won't mark offenses for _Metrics/XXXLength_ if you add lines to an already existing scope.
+
 
 Passing `files` as only argument is also supported for backward compatibility.
 


### PR DESCRIPTION
Hi, and thanks for the good work :clap:

Using the plugin, my team ended up being frustrated having Rubocop messages for contribution they didn't make.

Here is my way of solving this issue:
1. check out offenses as usual
2. check out which lines of code are new using `git.diff_for_file.patch`
3. removing offenses which are not within these lines of code

There is an issue left, that I documented: when you are dealing with block length issues such as `Metric/MethodLength`, they will be excluded if you are in an already created method. This is definitely fixable but I won't have the time here, and I think it is not mandatory yet, as long as it is documented.

Tell me what you think,
I'd love to see that merged asap, in the mean time I'll use a little hack to make it work in my team's (@klaxit) projects 🙂