### PR TITLE
Document the instructions for having Danger comment only on changed lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ public_files = (git.modified_files + git.added_files).select { |path| path.inclu
 rubocop.lint public_files
 ```
 
+> Submit comments only for changed lines
+
+```ruby
+github.dismiss_out_of_range_messages
+rubocop.lint inline_comment: true
+```
 
 #### Methods
 


### PR DESCRIPTION
### Problem
When submitting the inline comment, if the referenced line is not present in the patch, Danger aggregates the message into a main comment (see at the end of Github reference here: https://danger.systems/reference.html ). which is usually not a desired outcome.

### Solution
Fortunately the problem can be solved without adding any complexity to `danger-rubocop` - by using Danger DSL instead.

It feels like a pretty popular use case, so I thought it may be worth adding it to the README

Closes #28