### PR TITLE
Fix added_lines method returns 1 more line number

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -86,8 +86,8 @@ module Danger
            # Get start from diff.
            lineno = first_line.match(/\+(\d+),(\d+)/).captures.first.to_i
            diff.each_with_object([]) do |current_line, added_lines|
-             lineno += 1 unless current_line.start_with?('-')
              added_lines << lineno if current_line.start_with?('+')
+             lineno += 1 unless current_line.start_with?('-')
              added_lines
            end
          end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -20,7 +20,7 @@ module Danger
               'offenses' => [
                 {
                   'message' => 'No.',
-                  'location' => { 'line' => 42 }
+                  'location' => { 'line' => 41 }
                 }
               ]
             }
@@ -79,7 +79,7 @@ module Danger
                 'offenses' => [
                   {
                     'message' => 'No.',
-                    'location' => { 'line' => 42 }
+                    'location' => { 'line' => 41 }
                   }
                 ]
               }

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -88,6 +88,27 @@ module Danger
         end
       end
 
+      describe :added_lines do
+        before do
+          allow(@rubocop.git).to receive(:diff_for_file).with('SAMPLE') do
+            instance_double('Git::Diff::DiffFile', patch: <<~DIFF)
+            diff --git a/SAMPLE b/SAMPLE
+            new file mode 100644
+            index 0000000..7bba8c8
+            --- /dev/null
+            +++ b/SAMPLE
+            @@ -0,0 +1,2 @@
+            +line 1
+            +line 2
+            DIFF
+          end
+        end
+
+        it 'handles git diff' do
+          expect(@rubocop.send(:added_lines, 'SAMPLE')).to eq([1, 2])
+        end
+      end
+
       describe :lint_files do
         let(:response_ruby_file) do
           {


### PR DESCRIPTION
#30 adds `only_report_new_offenses` options, but it might mistake line number (less 1 line).

For example, I create empty file:

```
line 1
line 2
```

git diff says:
```diff
diff --git a/SAMPLE b/SAMPLE
new file mode 100644
index 0000000..7bba8c8
--- /dev/null
+++ b/SAMPLE
@@ -0,0 +1,2 @@
+line 1
+line 2
```

`+1,2` means first line and second line are changed.

But current implementation says `[2, 3]` lines changed (`DangerRubocop#added_lines`).