### PR TITLE
Add include_cop_names config var

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ rubocop.lint inline_comment: true
 
 Runs Ruby files through Rubocop. Generates a `markdown` list of warnings.
 
-This method accepts configuration hash.
+This method accepts a configuration hash.
 The following keys are supported:
 
 * `files`: array of file names or glob patterns to determine files to lint
@@ -56,6 +56,7 @@ The following keys are supported:
 * `config`: path to the `.rubocop.yml` file.
 * `only_report_new_offenses`: pass `true` to only report offenses that are in current user's scope.
    Note that this won't mark offenses for _Metrics/XXXLength_ if you add lines to an already existing scope.
+* `include_cop_names`: Prepends cop names to the output messages. Example: "Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end."
 
 
 Passing `files` as only argument is also supported for backward compatibility.

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -117,6 +117,7 @@ module Danger
                 'path' => 'spec/fixtures/ruby_file.rb',
                 'offenses' => [
                   {
+                    'cop_name' => 'Syntax/WhetherYouShouldDoThat',
                     'message' => "Don't do that!",
                     'location' => { 'line' => 13 }
                   }
@@ -133,6 +134,7 @@ module Danger
                 'path' => 'spec/fixtures/another_ruby_file.rb',
                 'offenses' => [
                   {
+                    'cop_name' => 'Syntax/WhetherYouShouldDoThat',
                     'message' => "Don't do that!",
                     'location' => { 'line' => 23 }
                   }
@@ -156,6 +158,22 @@ module Danger
           expect(output).to include('Rubocop violations')
           # A warning
           expect(output).to include("spec/fixtures/ruby_file.rb | 13   | Don't do that!")
+        end
+
+        it 'includes cop names when include_cop_names is set' do
+          allow(@rubocop).to receive(:`)
+            .with('bundle exec rubocop -f json --config path/to/rubocop.yml spec/fixtures/ruby_file.rb')
+            .and_return(response_ruby_file)
+
+          # Do it
+          @rubocop.lint(files: 'spec/fixtures/ruby*.rb', config: 'path/to/rubocop.yml', include_cop_names:  true)
+
+          output = @rubocop.status_report[:markdowns].first.message
+
+          # A title
+          expect(output).to include('Rubocop violations')
+          # A warning
+          expect(output).to include("spec/fixtures/ruby_file.rb | 13   | Syntax/WhetherYouShouldDoThat: Don't do that!")
         end
 
         it 'handles a rubocop report for specified files (legacy)' do


### PR DESCRIPTION
When `include_cop_names` is set to something truthy, `#lint` prepends cop names to the output messages.
Example: "Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end."