### PR TITLE
Add minimum rubocop requirement

### DIFF
--- a/danger-rubocop.gemspec
+++ b/danger-rubocop.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'danger'
-  spec.add_dependency 'rubocop'
+  spec.add_dependency 'rubocop', '~> 0.83'
 
   # General ruby development
   spec.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
With the addition of `--only-recognized-file-types` flag, the plugin
broke backwards compatibility with older versions of rubocop. For
example, running on 0.82.0 now fails with
```
invalid option: --only-recognized-file-types
```

This adds a minimum version requirement in the gemspec so we can release
a new version with the proper compatibility.

Related: https://github.com/ashfurrow/danger-rubocop/pull/39