### PR TITLE
Handle new files that have a single line

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -85,7 +85,7 @@ module Danger
          .flat_map do |chunk|
            first_line, *diff = chunk.split("\n")
            # Get start from diff.
-           lineno = first_line.match(/\+(\d+),(\d+)/).captures.first.to_i
+           lineno = first_line.match(/\+(\d+),?(\d?)/).captures.first.to_i
            diff.each_with_object([]) do |current_line, added_lines|
              added_lines << lineno if current_line.start_with?('+')
              lineno += 1 unless current_line.start_with?('-')

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -107,6 +107,26 @@ module Danger
         it 'handles git diff' do
           expect(@rubocop.send(:added_lines, 'SAMPLE')).to eq([1, 2])
         end
+
+        context "single line added to a new file" do
+          before do
+            allow(@rubocop.git).to receive(:diff_for_file).with('SAMPLE') do
+              instance_double('Git::Diff::DiffFile', patch: <<~DIFF)
+              diff --git a/SAMPLE b/SAMPLE
+              new file mode 100644
+              index 0000000..7bba8c8
+              --- /dev/null
+              +++ b/SAMPLE
+              @@ -0,0 +1 @@
+              +line 1
+              DIFF
+            end
+          end
+
+          it 'handles git diff' do
+            expect(@rubocop.send(:added_lines, 'SAMPLE')).to eq([1])
+          end
+        end
       end
 
       describe :lint_files do


### PR DESCRIPTION
## Problem
`danger-rubocop` fails to check new files that only have a single line and instead results in `NoMethodError:  undefined method 'captures' for nil:NilClass`

This is due the the git diff not matching the original regex.

## Solution
Account for diff hunk identifiers that have the format `@@ -\d,\d +\d @@`