### PR TITLE
Fixed a bug that an error occurs when only deleted files are used

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -78,7 +78,10 @@ module Danger
     end
 
     def added_lines(path)
-      git.diff_for_file(path)
+      diff_for_file = git.diff_for_file(path)
+      return [] if diff_for_file.nil?
+
+      diff_for_file
          .patch
          .split("\n@@")
          .tap(&:shift)

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -127,6 +127,16 @@ module Danger
             expect(@rubocop.send(:added_lines, 'SAMPLE')).to eq([1])
           end
         end
+
+        context 'no such file' do
+          before do
+            allow(@rubocop.git).to receive(:diff_for_file).with('SAMPLE').and_return(nil)
+          end
+
+          it 'return empty array' do
+            expect(@rubocop.send(:added_lines, 'SAMPLE')).to eq([])
+          end
+        end
       end
 
       describe :lint_files do


### PR DESCRIPTION
An error occurs when executing danger-rubocop with a pull request to delete a file only.

The `git.diff_for_file(path)` executed in the added_lines method appears to return nil if no file is added and changed.
So, Added a nil check for that pattern to prevent the error from occurring.

ref: https://github.com/danger/danger/blob/973bd6cdaf43bb08bab78cc1c98dd1e9ecc1a82b/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb#L130-L132