### PR TITLE
Support standardrb

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -36,9 +36,10 @@ module Danger
       inline_comment = config[:inline_comment] || false
       fail_on_inline_comment = config[:fail_on_inline_comment] || false
       include_cop_names = config[:include_cop_names] || false
+      rubocop_cmd = config[:rubocop_cmd] || 'rubocop'
 
       files_to_lint = fetch_files_to_lint(files)
-      files_to_report = rubocop(files_to_lint, force_exclusion, only_report_new_offenses, config_path: config_path)
+      files_to_report = rubocop(files_to_lint, force_exclusion, only_report_new_offenses, cmd: rubocop_cmd, config_path: config_path)
 
       return if files_to_report.empty?
       return report_failures files_to_report if report_danger
@@ -52,8 +53,8 @@ module Danger
 
     private
 
-    def rubocop(files_to_lint, force_exclusion, only_report_new_offenses, config_path: nil)
-      base_command = ['rubocop', '-f', 'json', '--only-recognized-file-types']
+    def rubocop(files_to_lint, force_exclusion, only_report_new_offenses, cmd: 'rubocop', config_path: nil)
+      base_command = [cmd, '-f', 'json', '--only-recognized-file-types']
       base_command.concat(['--force-exclusion']) if force_exclusion
       base_command.concat(['--config', config_path.shellescape]) unless config_path.nil?
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -312,6 +312,17 @@ EOS
                 .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13, type: error }")
             end
           end
+
+          context 'using standardrb cmd' do
+            it 'executes using the standardrb cmd' do
+              allow(@rubocop).to receive(:`)
+                .with('bundle exec standardrb -f json --only-recognized-file-types --config path/to/rubocop.yml spec/fixtures/ruby_file.rb')
+                .and_return(response_ruby_file)
+
+              # Do it
+              @rubocop.lint(files: 'spec/fixtures/ruby*.rb', rubocop_cmd: 'standardrb', config: 'path/to/rubocop.yml')
+            end
+          end
         end
 
         describe 'a filename with special characters' do


### PR DESCRIPTION
We recently moved to [Standard](https://github.com/testdouble/standard/) and I wanted to replicate the experience we had with danger-rubocop. I was about to fork this gem and make a danger-standard but then realised, why not just adapt this one to call `standardrb`? 

`standardrb` is a wrapper around rubocop so I've added a "rubocop_cmd" option to allow us to pass the executable. It defaults to `rubocop` but the user can pass in something else like `standardrb`

Another option would be to make this less generic and just have something like a flag `standard: true`. 

Let me know what you think