### PR TITLE
Delegate keyword arguments for Ruby 3.0

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -129,17 +129,14 @@ module Danger
         file['offenses'].map do |offense|
           offense_message = offense['message']
           offense_message = offense['cop_name'] + ': ' + offense_message if include_cop_names
-          arguments = [
-            offense_message,
-            {
-              file: file['path'],
-              line: offense['location']['line']
-            }
-          ]
+          kargs = {
+            file: file['path'],
+            line: offense['location']['line']
+          }
           if fail_on_inline_comment
-            fail(*arguments)
+            fail(offense_message, **kargs)
           else
-            warn(*arguments)
+            warn(offense_message, **kargs)
           end
         end
       end


### PR DESCRIPTION
This is a fix for an issue reported at https://github.com/ashfurrow/danger-rubocop/issues/55.

With ruby3 support, the interface between Danger's `warn` and `fail` methods has changed.
ref: https://github.com/danger/danger/pull/1286

This PR follows Danger's changes so that no error occurs when danger-rubocop is executed in the Ruby3 environment.