### PR TITLE
report severity of error based on Rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following keys are supported:
   despite the plugin providing the list of files explicitly)
 * `inline_comment`: pass `true` to comment inline of the diffs.
 * `fail_on_inline_comment`: pass `true` to use `fail` instead of `warn` on inline comment.
+* `report_severity`: pass `true` to use `fail` or `warn` based on Rubocop severity.
 * `report_danger`: pass true to report errors to Danger, and break CI.
 * `config`: path to the `.rubocop.yml` file.
 * `only_report_new_offenses`: pass `true` to only report offenses that are in current user's scope.

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -1,5 +1,5 @@
 require File.expand_path('spec_helper', __dir__)
-require 'debug'
+
 module Danger
   describe DangerRubocop do
     it 'is a plugin' do


### PR DESCRIPTION
The `fail_on_inline_comment` options either always fails or always warns. Rubocop returns a severity level with each offense. Instead of always failing or always warning, there should be an option to fail or warn depending on Rubocop's severity.