### PR TITLE
Include cop names in Danger failures

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -43,7 +43,7 @@ module Danger
       files_to_report = rubocop(files_to_lint, force_exclusion, only_report_new_offenses, cmd: rubocop_cmd, config_path: config_path)
 
       return if files_to_report.empty?
-      return report_failures files_to_report if report_danger
+      return report_failures(files_to_report, include_cop_names: include_cop_names) if report_danger
 
       if inline_comment
         add_violation_for_each_line(files_to_report, fail_on_inline_comment, report_severity, include_cop_names: include_cop_names)
@@ -116,10 +116,11 @@ module Danger
       message + table.split("\n")[1..-2].join("\n")
     end
 
-    def report_failures(offending_files)
+    def report_failures(offending_files, include_cop_names: false)
       offending_files.each do |file|
         file['offenses'].each do |offense|
-          fail "#{file['path']} | #{offense['location']['line']} | #{offense['message']}"
+          offense_message = offense_message(offense, include_cop_names: include_cop_names)
+          fail "#{file['path']} | #{offense['location']['line']} | #{offense_message}"
         end
       end
     end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -108,8 +108,7 @@ module Danger
         style: { border_i: '|' },
         rows: offending_files.flat_map do |file|
           file['offenses'].map do |offense|
-            offense_message = offense['message']
-            offense_message = offense['cop_name'] + ': ' + offense_message if include_cop_names
+            offense_message = offense_message(offense, include_cop_names: include_cop_names)
             [file['path'], offense['location']['line'], offense_message]
           end
         end
@@ -128,8 +127,7 @@ module Danger
     def add_violation_for_each_line(offending_files, fail_on_inline_comment, report_severity, include_cop_names: false)
       offending_files.flat_map do |file|
         file['offenses'].map do |offense|
-          offense_message = offense['message']
-          offense_message = offense['cop_name'] + ': ' + offense_message if include_cop_names
+          offense_message = offense_message(offense, include_cop_names: include_cop_names)
           kargs = {
             file: file['path'],
             line: offense['location']['line']
@@ -154,6 +152,12 @@ module Danger
         Dir.glob(files)
       end
       Shellwords.join(to_lint)
+    end
+
+    def offense_message(offense, include_cop_names: false)
+      return offense['message'] unless include_cop_names
+
+      "#{offense['cop_name']}: #{offense['message']}"
     end
   end
 end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -314,54 +314,54 @@ EOS
                 .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13, type: error }")
             end
           end
+        end
 
-          context 'with report_severity option' do
-            context 'file with error' do
-              it 'reports violations by rubocop severity' do
-                allow(@rubocop.git).to receive(:added_files).and_return([])
-                allow(@rubocop.git).to receive(:modified_files)
-                  .and_return(["spec/fixtures/another_ruby_file.rb"])
-                allow(@rubocop.git).to receive(:renamed_files).and_return([])
+        context 'with report_severity option' do
+          context 'file with error' do
+            it 'reports violations by rubocop severity' do
+              allow(@rubocop.git).to receive(:added_files).and_return([])
+              allow(@rubocop.git).to receive(:modified_files)
+                .and_return(["spec/fixtures/another_ruby_file.rb"])
+              allow(@rubocop.git).to receive(:renamed_files).and_return([])
 
-                allow(@rubocop).to receive(:`)
-                  .with('bundle exec rubocop -f json --only-recognized-file-types spec/fixtures/another_ruby_file.rb')
-                  .and_return(response_another_ruby_file)
+              allow(@rubocop).to receive(:`)
+                .with('bundle exec rubocop -f json --only-recognized-file-types spec/fixtures/another_ruby_file.rb')
+                .and_return(response_another_ruby_file)
 
-                @rubocop.lint(report_severity: true, inline_comment: true)
+              @rubocop.lint(report_severity: true, inline_comment: true)
 
-                expect(@rubocop.violation_report[:errors].first.to_s)
-                  .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/another_ruby_file.rb, line: 23, type: error }")
-              end
-            end
-
-            context 'file with warning' do
-              it 'reports violations by rubocop severity' do
-                allow(@rubocop.git).to receive(:added_files).and_return([])
-                allow(@rubocop.git).to receive(:modified_files)
-                  .and_return(["spec/fixtures/ruby_file.rb"])
-                allow(@rubocop.git).to receive(:renamed_files).and_return([])
-
-                allow(@rubocop).to receive(:`)
-                  .with('bundle exec rubocop -f json --only-recognized-file-types spec/fixtures/ruby_file.rb')
-                  .and_return(response_ruby_file)
-
-                @rubocop.lint(report_severity: true, inline_comment: true)
-
-                expect(@rubocop.violation_report[:warnings].first.to_s)
-                  .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13, type: warning }")
-              end
+              expect(@rubocop.violation_report[:errors].first.to_s)
+                .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/another_ruby_file.rb, line: 23, type: error }")
             end
           end
+        end
 
-          context 'using standardrb cmd' do
-            it 'executes using the standardrb cmd' do
-              allow(@rubocop).to receive(:`)
-                .with('bundle exec standardrb -f json --only-recognized-file-types --config path/to/rubocop.yml spec/fixtures/ruby_file.rb')
-                .and_return(response_ruby_file)
+        context 'file with warning' do
+          it 'reports violations by rubocop severity' do
+            allow(@rubocop.git).to receive(:added_files).and_return([])
+            allow(@rubocop.git).to receive(:modified_files)
+              .and_return(["spec/fixtures/ruby_file.rb"])
+            allow(@rubocop.git).to receive(:renamed_files).and_return([])
 
-              # Do it
-              @rubocop.lint(files: 'spec/fixtures/ruby*.rb', rubocop_cmd: 'standardrb', config: 'path/to/rubocop.yml')
-            end
+            allow(@rubocop).to receive(:`)
+              .with('bundle exec rubocop -f json --only-recognized-file-types spec/fixtures/ruby_file.rb')
+              .and_return(response_ruby_file)
+
+            @rubocop.lint(report_severity: true, inline_comment: true)
+
+            expect(@rubocop.violation_report[:warnings].first.to_s)
+              .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13, type: warning }")
+          end
+        end
+
+        context 'using standardrb cmd' do
+          it 'executes using the standardrb cmd' do
+            allow(@rubocop).to receive(:`)
+              .with('bundle exec standardrb -f json --only-recognized-file-types --config path/to/rubocop.yml spec/fixtures/ruby_file.rb')
+              .and_return(response_ruby_file)
+
+            # Do it
+            @rubocop.lint(files: 'spec/fixtures/ruby*.rb', rubocop_cmd: 'standardrb', config: 'path/to/rubocop.yml')
           end
         end
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -382,8 +382,7 @@ EOS
         end
 
         describe 'report to danger' do
-          let(:fail_msg) { %{spec/fixtures/ruby_file.rb | 13 | Don't do that!} }
-          it 'reports to danger' do
+          before do
             allow(@rubocop.git).to receive(:modified_files)
               .and_return(['spec/fixtures/ruby_file.rb'])
             allow(@rubocop.git).to receive(:added_files).and_return([])
@@ -391,9 +390,19 @@ EOS
             allow(@rubocop).to receive(:`)
               .with('bundle exec rubocop -f json --only-recognized-file-types spec/fixtures/ruby_file.rb')
               .and_return(response_ruby_file)
+          end
 
+          it 'reports to danger' do
+            fail_msg = %{spec/fixtures/ruby_file.rb | 13 | Don't do that!}
             expect(@rubocop).to receive(:fail).with(fail_msg)
             @rubocop.lint(report_danger: true)
+          end
+
+          it 'includes cop names when include_cop_names is set' do
+            fail_msg = %{spec/fixtures/ruby_file.rb | 13 | Syntax/WhetherYouShouldDoThat: Don't do that!}
+
+            expect(@rubocop).to receive(:fail).with(fail_msg)
+            @rubocop.lint(report_danger: true, include_cop_names: true)
           end
         end
       end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -299,7 +299,7 @@ EOS
           end
 
           context 'with fail_on_inline_comment option' do
-            it 'reports violations as line by line failures' do
+            before do
               allow(@rubocop.git).to receive(:modified_files)
                 .and_return(['spec/fixtures/ruby_file.rb'])
               allow(@rubocop.git).to receive(:added_files).and_return([])
@@ -307,11 +307,20 @@ EOS
               allow(@rubocop).to receive(:`)
                 .with('bundle exec rubocop -f json --only-recognized-file-types spec/fixtures/ruby_file.rb')
                 .and_return(response_ruby_file)
+            end
 
+            it 'reports violations as line by line failures' do
               @rubocop.lint(fail_on_inline_comment: true, inline_comment: true)
 
               expect(@rubocop.violation_report[:errors].first.to_s)
                 .to eq("Violation Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13, type: error }")
+            end
+
+            it 'includes cop names when include_cop_names is set' do
+              @rubocop.lint(fail_on_inline_comment: true, inline_comment: true, include_cop_names: true)
+
+              expect(@rubocop.violation_report[:errors].first.to_s)
+                .to eq("Violation Syntax/WhetherYouShouldDoThat: Don't do that! { sticky: false, file: spec/fixtures/ruby_file.rb, line: 13, type: error }")
             end
           end
         end


### PR DESCRIPTION
## Summary

Honor config option `include_cop_names` when used together with `report_failure`.

## Changes
-  Extract the offense message string generation to a new private method
- Support `include_cop_names` when reporting to Danger
- Fix nesting in spec file, specs were all nested within test for inline comments
- Add missing test for when including cop names together with inline comments

## Screenshots

### Before
![Screenshot 2023-09-08 at 09 23 15](https://github.com/ashfurrow/danger-rubocop/assets/681780/24965c87-926f-4d96-81bc-38c5ffe87f5c)

### After
![Screenshot 2023-09-08 at 09 21 35](https://github.com/ashfurrow/danger-rubocop/assets/681780/c0dc962e-7ebb-4b7f-a387-c6b3ba1311bd)
