### PR TITLE
Feature / Add option for grouping inline comments by line

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following keys are supported:
   (this option will instruct rubocop to ignore the files that your rubocop config ignores,
   despite the plugin providing the list of files explicitly)
 * `inline_comment`: pass `true` to comment inline of the diffs.
+* `group_inline_comments`: pass `true` to group inline comments to be a single comment on each line with all issues for that line.
 * `fail_on_inline_comment`: pass `true` to use `fail` instead of `warn` on inline comment.
 * `report_severity`: pass `true` to use `fail` or `warn` based on Rubocop severity.
 * `report_danger`: pass true to report errors to Danger, and break CI.


### PR DESCRIPTION
When there are multiple warnings on a single line, it makes a bit of a mess.
Added an option to group the issues on a single line into a single comment.

Lines with a single comment remain unchanged.

```
# Dangerfile
github.dismiss_out_of_range_messages
rubocop.lint rubocop_cmd: "standardrb", inline_comment: true, group_inline_comments: true
```
<img width="828" alt="Screenshot 2024-04-12 at 16 16 04" src="https://github.com/ashfurrow/danger-rubocop/assets/99471/a2560c01-d954-40e4-8a5f-989d20a7cd04">
