### PR TITLE
Add parameter to skip `bundle exec` prefix when running Rubocop

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The following keys are supported:
    Note that this won't mark offenses for _Metrics/XXXLength_ if you add lines to an already existing scope.
 * `include_cop_names`: Prepends cop names to the output messages. Example: "Layout/EmptyLinesAroundBlockBody: Extra empty line detected at block body end."
 * `rubocop_cmd`: Allows you to change the rubocop executable that's invoked. This is used to support rubocop wrappers like [Standard](https://github.com/testdouble/standard/) by passing `standardrb` as the value.
-
+* `skip_bundle_exec`: When there is a `Gemfile` in the project, Rubocop will be executed using [Bundler](https://bundler.io). When `true`, this flag will force Rubocop to run without `bundle exec`.
 
 Passing `files` as only argument is also supported for backward compatibility.
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -38,9 +38,10 @@ module Danger
       report_severity = config[:report_severity] || false
       include_cop_names = config[:include_cop_names] || false
       rubocop_cmd = config[:rubocop_cmd] || 'rubocop'
+      skip_bundle_exec = config[:skip_bundle_exec] || false
 
       files_to_lint = fetch_files_to_lint(files)
-      files_to_report = rubocop(files_to_lint, force_exclusion, only_report_new_offenses, cmd: rubocop_cmd, config_path: config_path)
+      files_to_report = rubocop(files_to_lint, force_exclusion, only_report_new_offenses, cmd: rubocop_cmd, config_path: config_path, skip_bundle_exec: skip_bundle_exec)
 
       return if files_to_report.empty?
       return report_failures(files_to_report, include_cop_names: include_cop_names) if report_danger
@@ -54,12 +55,12 @@ module Danger
 
     private
 
-    def rubocop(files_to_lint, force_exclusion, only_report_new_offenses, cmd: 'rubocop', config_path: nil)
+    def rubocop(files_to_lint, force_exclusion, only_report_new_offenses, cmd: 'rubocop', config_path: nil, skip_bundle_exec: false)
       base_command = [cmd, '-f', 'json', '--only-recognized-file-types']
       base_command.concat(['--force-exclusion']) if force_exclusion
       base_command.concat(['--config', config_path.shellescape]) unless config_path.nil?
 
-      rubocop_output = `#{'bundle exec ' if File.exist?('Gemfile')}#{base_command.join(' ')} #{files_to_lint}`
+      rubocop_output = `#{'bundle exec ' if File.exist?('Gemfile') && !skip_bundle_exec}#{base_command.join(' ')} #{files_to_lint}`
 
       return [] if rubocop_output.empty?
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -374,6 +374,34 @@ EOS
           end
         end
 
+        context 'using Bundler' do
+          it 'uses `bundle exec` when there is a Gemfile' do
+            allow(@rubocop).to receive(:`)
+              .with('bundle exec rubocop -f json --only-recognized-file-types --config path/to/rubocop.yml spec/fixtures/ruby_file.rb')
+              .and_return(response_ruby_file)
+
+            @rubocop.lint(files: 'spec/fixtures/ruby*.rb', config: 'path/to/rubocop.yml')
+          end
+
+          it 'doesn\'t use `bundle exec` when there is no Gemfile' do
+            allow(File).to receive(:exist?).with('Gemfile').and_return(false)
+
+            allow(@rubocop).to receive(:`)
+              .with('rubocop -f json --only-recognized-file-types --config path/to/rubocop.yml spec/fixtures/ruby_file.rb')
+              .and_return(response_ruby_file)
+
+            @rubocop.lint(files: 'spec/fixtures/ruby*.rb', config: 'path/to/rubocop.yml')
+          end
+
+          it 'doesn\'t use `bundle exec` when there is a Gemfile but skip_bundle_exec is true' do
+            allow(@rubocop).to receive(:`)
+              .with('rubocop -f json --only-recognized-file-types --config path/to/rubocop.yml spec/fixtures/ruby_file.rb')
+              .and_return(response_ruby_file)
+
+            @rubocop.lint(files: 'spec/fixtures/ruby*.rb', config: 'path/to/rubocop.yml', skip_bundle_exec: true)
+          end
+        end
+
         describe 'a filename with special characters' do
           it 'is shell escaped' do
             modified_files = [


### PR DESCRIPTION
I came across the following situation: I needed to run Rubocop from a CI agent, specifically not running it using Bundler as I don't want to install any other of the project's gems.

This led to a failure as `danger-rubocop` always uses `bundle exec` when there is a `Gemfile` in the project.

This PR adds a parameter to force `danger-rubocop` not to append `bundle exec` even when a `Gemfile` is present.